### PR TITLE
Trabalha sempre com a última versão do buildpack

### DIFF
--- a/rootfs/builder/install-buildpacks
+++ b/rootfs/builder/install-buildpacks
@@ -1,42 +1,36 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-BUILDPACK_INSTALL_PATH="/tmp/buildpacks"
+BUILDPACK_INSTALL_PATH="./tmp/buildpacks"
 
 download_buildpack() {
     buildpack_url="$1"
-    buildpack_commit="$2"
-    buildpack_name="$3"
+    buildpack_name="$2"
 
     echo "Fetching $buildpack_name..."
 
     set +e
-    git clone --branch "$buildpack_commit" --depth 1 "$buildpack_url" $BUILDPACK_INSTALL_PATH/"$buildpack_name" &>/dev/null
-    SHALLOW_CLONED=$?
-    set -e
-    if [ $SHALLOW_CLONED -ne 0 ]; then
-        # if the shallow clone failed partway through, clean up and try a full clone
-        rm -rf "${BUILDPACK_INSTALL_PATH:?}"/"$buildpack_name"
-        git clone --quiet "$buildpack_url" $BUILDPACK_INSTALL_PATH/"$buildpack_name"
-        pushd $BUILDPACK_INSTALL_PATH/"$buildpack_name" &>/dev/null
-            git checkout --quiet "$buildpack_commit"
-        popd &>/dev/null
-    fi
+    git clone "$buildpack_url" $BUILDPACK_INSTALL_PATH/"$buildpack_name"; \
+    pushd $BUILDPACK_INSTALL_PATH/"$buildpack_name" &>/dev/null
+        git fetch --quiet --tags; buildpack_commit=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=0 --max-count=1)); \
+        git checkout --quiet "$buildpack_commit"
+    popd &>/dev/null; \
+    echo "Buildpack version: $buildpack_commit"
 
     echo "Done."
 }
 
 mkdir -p $BUILDPACK_INSTALL_PATH
 
-download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          v1.0.0   01-multi
-download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v77      02-clojure
-download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v81      03-go
-download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v23      04-gradle
-download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v21      05-grails
-download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v59      06-java
-download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v118     07-nodejs
-download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v121     08-php
-download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v26      09-play
-download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v123     10-python
-download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v167     11-ruby
-download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v77      12-scala
+download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          01-multi
+download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        02-clojure
+download_buildpack https://github.com/heroku/heroku-buildpack-go.git             03-go
+download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         04-gradle
+download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         05-grails
+download_buildpack https://github.com/heroku/heroku-buildpack-java.git           06-java
+download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         07-nodejs
+download_buildpack https://github.com/heroku/heroku-buildpack-php.git            08-php
+download_buildpack https://github.com/heroku/heroku-buildpack-play.git           09-play
+download_buildpack https://github.com/heroku/heroku-buildpack-python.git         10-python
+download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           11-ruby
+download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          12-scala


### PR DESCRIPTION
**Feature:**
- Busca as versões de cada buildpack e faz o checkout para trabalhar com a última versão.

**Observação:**
- Uma opção seria remover os arquivos do buildpack depois de ter pego a tag última versão do projeto e fazer novamente o download apenas com a última tag, só não sei se seria muito viável, pois demoraria mais ainda o processo de deploy.